### PR TITLE
Refine 'isCompatible()'.

### DIFF
--- a/blacktip_smart_cruise/pkgdesc.qml
+++ b/blacktip_smart_cruise/pkgdesc.qml
@@ -16,7 +16,7 @@ Item {
 
         // vesc, vesc bms or custom module
         // Note that VBMS32 is a custom module
-        var hwType = fwRxParams.hwTypeStr().toLowerCase();		
+        var hwType = fwRxParams.hwTypeStr().toLowerCase();
 
         console.log("HW Name: " + hwName)
         console.log("FW Name: " + fwName)
@@ -26,7 +26,11 @@ Item {
         if (hwType != "vesc") {
             return false
         }
-		
+
+        if (hwName != "410" && hwName != "60" && hwName != "60_mk5") {
+            return false
+        }
+
         return true
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tightened compatibility checks for VESC hardware. The app now verifies the specific hardware model and proceeds only on supported models (410, 60, 60 mk5). This prevents features from appearing or activating on unsupported devices, reducing setup errors and instability from misidentified hardware. Users with unsupported VESC variants will now see the hardware reported as incompatible instead of experiencing partial or unreliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->