### PR TITLE
Change the 'cruise mode duration' setting from minutes to seconds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PKGS = balance float refloat tnt vbms32 vbms32_micro
+PKGS = balance blacktip_smart_cruise float refloat tnt vbms32 vbms32_micro
 PKGS += lib_files lib_interpolation lib_nau7802 lib_pn532
 PKGS += lib_ws2812 logui lib_code_server lib_midi lib_disp_ui
 PKGS += vdisp lib_tca9535 vbms_harmony32

--- a/blacktip_smart_cruise/blacktip_smart_cruise.lisp
+++ b/blacktip_smart_cruise/blacktip_smart_cruise.lisp
@@ -21,7 +21,7 @@
 (eeprom-store-i 13 1) ; Turn safe start on or off 1=On 0=Off
 (eeprom-store-i 14 0) ; Enable Reverse speed. 1=On 0=Off 
 (eeprom-store-i 15 0) ; Enable 5 click Custom Control. 1=On 0=Off
-(eeprom-store-i 16 1) ; How long before custom control times out and requires reactivation in min.
+(eeprom-store-i 16 60) ; How long before custom control times out and requires reactivation in sec.
 (eeprom-store-i 17 0) ; Rotation of Display, 0-3 . Each number rotates display 90 deg.
 (eeprom-store-i 18 5) ; Display Brighness 0-5
 (eeprom-store-i 19 0) ; Bluetooth Wiring, 0 = Blacktip HW60 + Ble, 1 = Blacktip HW60 - Ble, 2 = Blacktip HW410 - Ble, 3 = Cuda-X HW60 + Ble, 4 = Cuda-X HW60 - Ble
@@ -398,7 +398,7 @@
                    
          
             (if (= Custom_Control 1); Require custom control to be re-enabled after a fixed duration 
-                (if (> (secs-since Timer_Start) (* Custom_Control_Timeout 60)); 
+                (if (> (secs-since Timer_Start) Custom_Control_Timeout); 
                     (progn
                     (setvar 'Custom_Control 0.5)
                     (setvar 'Timer_Start (systime))

--- a/blacktip_smart_cruise/ui.qml
+++ b/blacktip_smart_cruise/ui.qml
@@ -770,7 +770,7 @@ Item {
         da1.setUint8(13, 1)
         da1.setUint8(14, 0)
         da1.setUint8(15, 0)
-        da1.setUint8(16, 1)
+        da1.setUint8(16, 60)
         da1.setUint8(17, 0)
         da1.setUint8(18, 5)
         da1.setUint8(19, 0)
@@ -1280,11 +1280,11 @@ Dialog {
                         visible : true
                         decimals: 0
                         prefix: "Custom Timout: "
-                        suffix: " min."
-                        realFrom: 1
-                        realTo: 15
-                        realValue: 1
-                        realStepSize: 1.0
+                        suffix: " sec."
+                        realFrom: 10
+                        realTo: 240
+                        realValue: 60
+                        realStepSize: 10.0
                         onRealValueChanged: { write_settings()}
                     }
             }}


### PR DESCRIPTION
Signed-off-by: Michael Keller <github@ike.ch>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Blacktip Smart Cruise with a customizable Custom Control timeout measured in seconds.
  * Updated UI control for Custom Control timeout: now shows seconds (not minutes) with a wider, more precise range and step size for easier tuning.

* **Chores**
  * Build configuration updated to include Blacktip Smart Cruise, ensuring it’s packaged and available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->